### PR TITLE
Update to winapi 0.3.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ include = [
 ]
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.8"
-kernel32-sys = "0.2.2"
+winapi = {version= "0.3.9", features = ["wow64apiset", "processthreadsapi", "errhandlingapi"]}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,17 @@
 
 #[cfg(windows)]
 extern crate winapi;
-#[cfg(windows)]
-extern crate kernel32;
 
-use winapi::BOOL;
-use kernel32::{IsWow64Process, GetCurrentProcess, GetLastError};
+use winapi::{
+    shared::minwindef::BOOL,
+    um::{
+        errhandlingapi::GetLastError, processthreadsapi::GetCurrentProcess,
+        wow64apiset::IsWow64Process,
+    },
+};
 
 #[cfg(windows)]
-pub fn iswow64() -> Result<bool, u32>{
+pub fn iswow64() -> Result<bool, u32> {
     let mut is_wow64: BOOL = 0;
     unsafe {
         match IsWow64Process(GetCurrentProcess(), &mut is_wow64) {


### PR DESCRIPTION
This updates winapi usage to 0.3.9 to be more compatible with other crates.

Please consider a new release (maybe even a 1.0) after merging this.